### PR TITLE
Bump commons-io from 1.3.2 to 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.3.2</version>
+            <version>2.7</version>
         </dependency>
 		<dependency>
 			<groupId>net.logstash.logback</groupId>


### PR DESCRIPTION
Bumps commons-io from 1.3.2 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>